### PR TITLE
6 use an existing crawl results if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ npm i -g selector-hound
 
 ## Usage
 
+### Basic Scanning
 Only scan the first 20 pages for `.yourthing`
 
 ```
@@ -41,20 +42,56 @@ SelectorHound --sitemap=https://wherever.com/xml --limit=20 --selector=".yourthi
 SelectorHound -u https://wherever.com/xml -l 20 -s ".yourthing"
 ```
 
-Scan the first 20 pages and take screenshots
+### Re-using, regenerating, and providing a list of links
+Before the site scanning begins, this generates a `<site>.sitemap.json` file containing all of the links it will scan. This file is generated from the `sitemap.xml` file you provided **or** from crawling the site looking for links. To improve performance, SelectorHound will look for this file _first_ before attempting to retrieve/generate a sitemap. 
+
+If you want to re-generate this `<site>.sitemap.json` file, you can force it:
+
 ```
+SelectorHound --sitemap=https://wherever.com/xml  --selector=".yourthing" --dontUseExportedSitemap
+SelectorHound -u https://mysite.com/landing -r -s '.yourThing' -X
+```
+
+#### Formatting
+By default, SelectorHound will generate a format that's based off of how sitemap XML looks, which is an array of objects with a `loc` property:
+```JavaScript
+[
+    {
+        'loc': 'https://mysite.com/path'
+    },
+    {
+        'loc': 'https://mysite.com/another'
+    }
+]
+```
+
+However, you can also provide your own list of links as just an array of strings:
+```JavaScript
+    [
+        "https://mysite.com/path",
+        "https://mysite.com/another"
+    ]
+```
+
+
+
+### Crawling instead of using a sitemap
+Crawl the site, starting from a landing page.
+
+```shell
+SelectorHound -u https://mysite.com/landing -r -s ".myClass"
+```
+
+### Taking Screenshots or dealing with SPAs
+Scan the first 20 pages and take screenshots
+```shell
 SelectorHound -u https://wherever.com/xml -l 20 -s ".yourthing" -c
 ```
 
 Scan those pages, but treat them like Single Page Applications (`-d`), and search for all the selectors in `mystyles.css`
-```
+```shell
 SelectorHound -u https://wherever.com/xml -f "mystyles.css" -d
 
-```
-
-Crawl the site, starting from a landing page
-```
-SelectorHound -u https://mysite.com/landing -r -s ".myClass"
 ```
 
 ### Options
@@ -62,6 +99,7 @@ SelectorHound -u https://mysite.com/landing -r -s ".myClass"
 | Option | Alias | Description   | Defaults  |
 |---|---|---|---|
 | `--sitemap` |`-u`  | Must be fully qualified URL to an XML Sitemap **or** fully qualified URL to a page **if** `crawl` is `true`. Required. | `https://frankmtaylor.com/sitemap.xml` |
+| `--dontUseExportedSitemap` |`-X`  | if a `<site>.sitemap.json` file has been already been created, ignore it and generate a new one. Optional. | `false` |
 | `--limit` | `-l`  |  Maximum number of pages to crawl. Optional. | `0`  |
 | `--selector` | `-s`  |  A valid CSS selector. Required. |  `.title` |
 | `--cssFile` | `-f`  | A CSS file to use instead of a single selector. Optional. |   |

--- a/test/site-crawler.test.js
+++ b/test/site-crawler.test.js
@@ -146,6 +146,8 @@ describe('SiteCrawler:Crawling', () => {
       expect(SiteCrawler).toHaveProperty('defaultConfig');
       expect(SiteCrawler.defaultConfig).toHaveProperty('startPage', 'https://frankmtaylor.com');
       expect(SiteCrawler.defaultConfig).toHaveProperty('linkSelector', 'a[href]');
+      expect(SiteCrawler.defaultConfig).toHaveProperty('shouldCrawl', false);
+      expect(SiteCrawler.defaultConfig).toHaveProperty('useExportedSitemap', true);
     });
   });
   describe('static getPageAsync', () => {
@@ -217,6 +219,25 @@ describe('SiteCrawler:Crawling', () => {
       expect(filteredLinks).toEqual(
         expect.arrayContaining(['/foo', '/foo/bar', '/foo#beep']),
       );
+    });
+  });
+  describe('getters', () => {
+    const siteCrawler = new SiteCrawler();
+
+    test('it has an origin', () => {
+      expect(siteCrawler.origin).toEqual('https://frankmtaylor.com');
+    });
+    test('it has an host', () => {
+      expect(siteCrawler.host).toEqual('frankmtaylor.com');
+    });
+    test('exportFileName', () => {
+      expect(siteCrawler.exportFileName).toEqual('frankmtaylor.com');
+    });
+    test('pathToExportedFile', () => {
+      expect(siteCrawler.pathToExportedFile).toEqual(`${process.cwd()}/frankmtaylor.com.sitemap.json`);
+    });
+    test('hasExportedLinks', () => {
+      expect(siteCrawler.hasExportedLinks).toEqual(false);
     });
   });
   describe('getLinksFromPageAsync', () => {
@@ -364,6 +385,13 @@ describe('SiteCrawler: Fetching Sitemap', () => {
       const siteCrawler = new SiteCrawler({ startPage: 'https://frankmtaylor.com/sitemap.xml' });
       await siteCrawler.setSitemap();
       expect(siteCrawler.urlset.length).toEqual(7);
+    });
+  });
+  describe('produceSiteLinks', () => {
+    test('when produceSiteLinks is run, a file is created and it knows it', async () => {
+      const siteCrawler = new SiteCrawler({ startPage: 'https://frankmtaylor.com/sitemap.xml' });
+      await siteCrawler.produceSiteLinks();
+      expect(siteCrawler.hasExportedLinks).toEqual(true);
     });
   });
 });

--- a/test/site-crawler.test.js
+++ b/test/site-crawler.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 const axios = require('axios');
-
+const fs = require('fs');
 const SiteCrawler = require('../src/site-crawler');
 
 jest.mock('axios');
@@ -122,6 +122,10 @@ axios.mockImplementation((url) => {
     default:
       return Promise.resolve({ data: MOCK_DATA.default });
   }
+});
+
+afterAll(async () => {
+  await fs.promises.unlink('frankmtaylor.com.sitemap.json');
 });
 
 describe('getting file', () => {
@@ -388,10 +392,12 @@ describe('SiteCrawler: Fetching Sitemap', () => {
     });
   });
   describe('produceSiteLinks', () => {
-    test('when produceSiteLinks is run, a file is created and it knows it', async () => {
+    test('when produceSiteLinks is run, a file is created and it knows it, and still has data', async () => {
       const siteCrawler = new SiteCrawler({ startPage: 'https://frankmtaylor.com/sitemap.xml' });
       await siteCrawler.produceSiteLinks();
       expect(siteCrawler.hasExportedLinks).toEqual(true);
+      expect(siteCrawler.linkSet.size).toBeGreaterThan(0);
+      expect(siteCrawler.linkSet.has('http://frankmtaylor.com'));
     });
   });
 });


### PR DESCRIPTION
This actually solves the other issue of wanting to use a plain-text file of URLS, mostly b/c it can now read a JSON file formatted to look like XML OR just an array of strings